### PR TITLE
Adding Trello API add_link_to_card

### DIFF
--- a/startling_trello/lib/startling_trello/api.rb
+++ b/startling_trello/lib/startling_trello/api.rb
@@ -50,5 +50,15 @@ module StartlingTrello
       token = @client.find(:token, @member_token)
       @client.find(:member, token.member_id)
     end
+
+    def card_has_link?(card, url)
+      card.attachments().any? {|attachment| attachment.url == url}
+    end
+
+    def add_link_to_card(card, url)
+      unless card_has_link?(card, url)
+        card.add_attachment(url)
+      end
+    end
   end
 end

--- a/startling_trello/spec/startling_trello/api_spec.rb
+++ b/startling_trello/spec/startling_trello/api_spec.rb
@@ -95,5 +95,38 @@ module StartlingTrello
 
       api.add_member_to_card(card)
     end
+
+
+    describe '#add_link_to_card' do
+      let(:url) { 'https://github.com/substantial/startling/pull/3' }
+      let(:attachment) {
+        Trello::Attachment.new({
+          'id'           => 'abcdef123456789123456789',
+          'name'         => 'Pull Request',
+          'url'          => 'https://github.com/substantial/startling/pull/3',
+          'bytes'        => 0,
+          'idMember'     => 'abcdef123456789123456781',
+          'isUpload'     => false,
+          'date'         => '2013-02-28T17:12:28.497Z',
+          'previews'     => 'previews'
+        })
+      }
+
+      it 'adds a url attachment to the card' do
+        card = double(:card)
+        allow(card).to receive(:attachments) { [] }
+        expect(card).to receive(:add_attachment)
+
+        api.add_link_to_card(card, url)
+      end
+
+      it 'does not add a link to the card if there already is one' do
+        card = double(:card)
+        allow(card).to receive(:attachments) { [ attachment ] }
+        expect(card).not_to receive(:add_attachment)
+
+        api.add_link_to_card(card, url)
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi Substantial! I'm finding it would be helpful to have a link from the Trello card back to the PRs that were opened for it. I can create an `after_pull_request` hook to do that, but it seems things would be a bit easier if I added a function in the startling_trello Api class. If you think a `link_trello_to_pr` command would be a good fit for the main fork here, I can add that to this pull request or in a separate one.

Thanks a lot. I'm really digging some of the tools you have built - especially [mergeq](https://github.com/aaronjensen/mergeq). That does some amazing tricks with git to record and replay merges.
